### PR TITLE
Paralelismos para aumentar caudal de tweets

### DIFF
--- a/PulseNestCoreMVC/Controllers/BackgroundListener.cs
+++ b/PulseNestCoreMVC/Controllers/BackgroundListener.cs
@@ -32,6 +32,11 @@ namespace PulseNestCoreMVC.Controllers
         private int tweetsSinCoordenadas = 0;
         private int tweetsSinSentimiento = 0;
         private double procentajeExito = 0.0;
+        static int tweetsfelicidad = 0;
+        static int tweetsascoEIra = 0;
+        static int tweetsmiedoOSorpresa = 0;
+        static int tweetstristeza = 0;
+
 
         List<mapPoint> pool = new List<mapPoint>();
         Random rdm = new Random();
@@ -68,7 +73,7 @@ namespace PulseNestCoreMVC.Controllers
                     miedoOSorpresa = feelings.Find(x => x.name.Contains("miedoOSorpresa")).words.ToString();
                     tristeza = feelings.Find(x => x.name.Contains("tristeza")).words.ToString();
 
-                    searchString = felicidad + ", " + ascoEIra + ", " + miedoOSorpresa + ", " + tristeza;
+                    searchString = tristeza + ", " + ascoEIra + ", " + felicidad + ", " +  miedoOSorpresa;
 
                     aFelicidad = felicidad.Split(new string[] { ", " }, StringSplitOptions.None);
                     aAscoEIra = ascoEIra.Split(new string[] { ", " }, StringSplitOptions.None);
@@ -81,7 +86,9 @@ namespace PulseNestCoreMVC.Controllers
         protected async override Task ExecuteAsync(CancellationToken stoppingToken)
         {           
             listen(stoppingToken);
+            listen(stoppingToken);
             drawing(stoppingToken);
+
         }
 
         private async Task listen(CancellationToken stoppingToken)
@@ -113,9 +120,7 @@ namespace PulseNestCoreMVC.Controllers
                catch (Exception e) {
                 _logger.LogError(e.Message);
                 listen(stoppingToken);
-            }
-            
-                
+            }           
 
         }
 
@@ -133,20 +138,28 @@ namespace PulseNestCoreMVC.Controllers
                 tweet = tweet.ToLower().Replace('#', ' ');
 
                 bool felicidad = aFelicidad.Any(palabra => tweet.IndexOf(palabra, StringComparison.OrdinalIgnoreCase) >= 0); ;
-                if (felicidad)
+                if (felicidad){
+                    tweetsfelicidad++;
                     return Feel.felicidad;
+                }
 
                 bool ascoEIra = aAscoEIra.Any(palabra => tweet.IndexOf(palabra, StringComparison.OrdinalIgnoreCase) >= 0);
-                if (ascoEIra)
+                if (ascoEIra) {
+                    tweetsascoEIra++;
                     return Feel.ascoEIra;
+                }
 
                 bool miedoOSorpresa = aMiedoOSorpresa.Any(palabra => tweet.IndexOf(palabra, StringComparison.OrdinalIgnoreCase) >= 0);
-                if (miedoOSorpresa)
+                if (miedoOSorpresa) {
+                    tweetsmiedoOSorpresa++;
                     return Feel.miedoOSorpresa;
+                }
 
                 bool tristeza = aTristeza.Any(palabra => tweet.IndexOf(palabra, StringComparison.OrdinalIgnoreCase) >= 0);
-                if (tristeza)
+                if (tristeza) {
+                    tweetstristeza++;
                     return Feel.tristeza;
+                }
 
                 if (json.SelectToken("retweeted_status") != null )
                     return analizeFeeling(json.SelectToken("retweeted_status"));

--- a/PulseNestCoreMVC/wwwroot/css/site.css
+++ b/PulseNestCoreMVC/wwwroot/css/site.css
@@ -1,14 +1,15 @@
 ﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification\ 
-for details on configuring this project to bundle and minify static web assets. */
+for details on configuring this project to bundle and minify static web assets. #130b81 */
 body {
     padding-top: 50px;
     padding-bottom: 20px;
     background-color: black;
 }
 
+
 svg {
     border: 2px solid black;
-    background-color: #130b81;
+    background-color: #6f8cb5 ;
 }
 
 .land {
@@ -20,6 +21,8 @@ svg {
     fill: black;
     stroke: black;
 }
+
+
 /* Wrapping element */
 /* Set some basic padding to keep content from hitting the edges */
 .body-content {
@@ -34,3 +37,5 @@ svg {
         display: none;
     }
 }
+
+


### PR DESCRIPTION
Se iba a añadir una task para cada sentimiento, pero, al menos para la versión gratuita del API, se devuelve excepción de límite de consultas alcanzadas. Se puede implementar para que las vuelva  lanzar pero en ese caso no hay estabilidad del flujo de tweets, con lo que se pierde la uniformidad y al final resulta en menos tweets variados. Se ha decidido crear una segunda Task que lance exactamente le mismo proceso con lo que se consigue un rango de 1,5 a 3 veces más tweets por segundo sin excepciones.